### PR TITLE
Add support for glob patterns

### DIFF
--- a/core/utility.py
+++ b/core/utility.py
@@ -24,7 +24,6 @@ class ForEachState:
             self._data = dict()
 
     def add_files_to_process(self, files):
-        files = list(map(lambda f: os.path.basename(f), files))
         all_files = set(self._data.keys())
         all_files.update(files)
         for filename in all_files:
@@ -35,7 +34,6 @@ class ForEachState:
             f.write(txt)
 
     def mark_done(self, filename):
-        filename = os.path.basename(filename)
         self._data[filename] = True
         with open(self._filepath, "w", encoding="utf8") as f:
             txt = json.dumps(self._data, indent=2)

--- a/utility.py
+++ b/utility.py
@@ -7,6 +7,7 @@ import glob
 
 from .categories import NodeCategories
 from .core import *
+from pathlib import Path
 
 
 class DVB_IntToString:
@@ -104,12 +105,12 @@ class DVB_ForEachFilename:
 
     def exec(self, id: str, directory: str, pattern: str):
         directory = directory.strip('"')
-        if not os.path.isdir(directory):
-            on_node_error(DVB_ForEachFilename, "Not a directory: {}".format(directory))
-
+        p = Path(directory)
+        parts = p.parts
+        idx = next((i for i, part in enumerate(parts) if any(ch in part for ch in "*?[]")), len(parts))
+        base2 = Path(*parts[:idx])
         foreach_filename = "foreach_" + id + ".json"
-
-        statefile = os.path.normpath(os.path.abspath(os.path.join(directory, foreach_filename)))
+        statefile = os.path.normpath(os.path.abspath(os.path.join(base2, foreach_filename)))
         search_path = os.path.normpath(os.path.abspath(directory))
         state = ForEachState(statefile)
 


### PR DESCRIPTION
First off, thank you for this repo! I love the custom nodes and am a huge power user of them. One thing, though, I needed the ability to glob for files within subdirectories which this doesn't support. 

This was my use case. Consider the following directory structure:
```
 .
└──  clips
    ├──  2025-10-04_22-23-30_UTC
    │   ├──  2025-10-04_22-23-30_UTC-Scene-001.mp4
    │   ├──  2025-10-04_22-23-30_UTC-Scene-002.mp4
    │   ├──  2025-10-04_22-23-30_UTC-Scene-003.mp4
    │   ├──  2025-10-04_22-23-30_UTC-Scene-004.mp4
    │   └──  2025-10-04_22-23-30_UTC-Scene-005.mp4
    ├──  2025-10-06_18-07-19_UTC
    │   ├──  2025-10-06_18-07-19_UTC-Scene-001.mp4
    │   ├──  2025-10-06_18-07-19_UTC-Scene-002.mp4
    │   └──  2025-10-06_18-07-19_UTC-Scene-003.mp4
    ├──  2025-10-06_20-35-25_UTC
    │   ├──  2025-10-06_20-35-25_UTC-Scene-001.mp4
    │   ├──  2025-10-06_20-35-25_UTC-Scene-002.mp4
    │   ├──  2025-10-06_20-35-25_UTC-Scene-003.mp4
    │   ├──  2025-10-06_20-35-25_UTC-Scene-004.mp4
    │   └──  2025-10-06_20-35-25_UTC-Scene-005.mp4
```

I wanted to be able to grab all the mp4 files within it. Unfortunately the `Foreach Filename` didn't support that. I updated it to use Python's `glob.glob` so it can support `**` patterns and I can set the folder to`clips/**/` and then file the pattern use `*.mp4`.

If you'd feel like this is a good addition to the custom node, please feel free to merge in or let me know if there are any additional changes you'd like me to make.